### PR TITLE
Fixed capitalization for user classname. Now works with names like "AdminUser".

### DIFF
--- a/lib/userstamp/migration_helper.rb
+++ b/lib/userstamp/migration_helper.rb
@@ -16,4 +16,6 @@ module Ddb
   end
 end
 
+# ActiveRecord::ConnectionAdapters::Table.send(:include, Ddb::Userstamp::MigrationHelper)
+ActiveRecord::ConnectionAdapters::TableDefinition.send(:include, Ddb::Userstamp::MigrationHelper)
 ActiveRecord::ConnectionAdapters::Table.send(:include, Ddb::Userstamp::MigrationHelper)

--- a/lib/userstamp/stampable.rb
+++ b/lib/userstamp/stampable.rb
@@ -149,3 +149,4 @@ module Ddb #:nodoc:
 end
 
 ActiveRecord::Base.send(:include, Ddb::Userstamp::Stampable) if defined?(ActiveRecord)
+


### PR DESCRIPTION
Thanks for this great gem. I had a small issue, where I had to use a username like "AdminUser". Capitalization was not working for a name like this.

I fixed it. Sorry for not supplying any tests. I'm short in time, ATM.

Best regards,

Roberto
