### PR TITLE
Update lib/userstamp/migration_helper.rb

### DIFF
--- a/lib/userstamp/migration_helper.rb
+++ b/lib/userstamp/migration_helper.rb
@@ -17,3 +17,4 @@ module Ddb
 end
 
 ActiveRecord::ConnectionAdapters::Table.send(:include, Ddb::Userstamp::MigrationHelper)
+ActiveRecord::ConnectionAdapters::TableDefinition.send(:include, Ddb::Userstamp::MigrationHelper)


### PR DESCRIPTION
Rails 3.2 fix.

Issue: 
undefined method `userstamps' for #<ActiveRecord::ConnectionAdapters::TableDefinition:0xa6d1014>