### PR TITLE
Update to Fix Deprecation

### DIFF
--- a/lib/userstamp.rb
+++ b/lib/userstamp.rb
@@ -14,8 +14,8 @@ module Ddb
     module Userstamp
       def self.included(base) # :nodoc:
         base.send           :include, InstanceMethods
-        base.before_filter  :set_stamper
-        base.after_filter   :reset_stamper
+        base.before_action  :set_stamper
+        base.after_action   :reset_stamper
       end
 
       module InstanceMethods


### PR DESCRIPTION
before_filter and after_filter are deprecated in Rails 5.0 and will be removed in 5.1 in favor of before_action and after_action

See https://github.com/rails/rails/blob/v5.0.0.beta2/actionpack/lib/abstract_controller/callbacks.rb#L190-L193 for reference

Thanks for taking a look.