### PR TITLE
Defer the inclusion until after ActiveRecord has been fully loaded

### DIFF
--- a/lib/userstamp/stampable.rb
+++ b/lib/userstamp/stampable.rb
@@ -81,13 +81,13 @@ module Ddb #:nodoc:
           class_eval do
             belongs_to :creator, :class_name => self.stamper_class_name.to_s.singularize.camelize,
                                  :foreign_key => self.creator_attribute
-                                 
+
             belongs_to :updater, :class_name => self.stamper_class_name.to_s.singularize.camelize,
                                  :foreign_key => self.updater_attribute
-                                 
+
             before_save     :set_updater_attribute
             before_create   :set_creator_attribute
-                                 
+
             if defined?(Caboose::Acts::Paranoid)
               belongs_to :deleter, :class_name => self.stamper_class_name.to_s.singularize.camelize,
                                    :foreign_key => self.deleter_attribute
@@ -148,4 +148,6 @@ module Ddb #:nodoc:
   end
 end
 
-ActiveRecord::Base.send(:include, Ddb::Userstamp::Stampable) if defined?(ActiveRecord)
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.send(:include, Ddb::Userstamp::Stampable)
+end

--- a/lib/userstamp/stamper.rb
+++ b/lib/userstamp/stamper.rb
@@ -40,4 +40,6 @@ module Ddb #:nodoc:
   end
 end
 
-ActiveRecord::Base.send(:include, Ddb::Userstamp::Stamper) if defined?(ActiveRecord)
+ActiveSupport.on_load(:active_record) do
+  ActiveRecord::Base.send(:include, Ddb::Userstamp::Stamper)
+end


### PR DESCRIPTION
## Issue Description
The current implementation references `ActiveRecord` as soon as the gem is loaded, which triggers premature loading of Active Record. This can significantly slow down application boot time, especially in development and test environments.

## Solution

Use Rails' recommended [ActiveSupport.on_load(:active_record)](https://edgeapi.rubyonrails.org/classes/ActiveSupport/LazyLoadHooks.html) hook to defer module inclusion until after `ActiveRecord` is fully loaded. This improves boot performance and avoids potential load order issues in edge cases.